### PR TITLE
Security audit hardening - May 2026

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Database/Schema/SqlAnywhereSchema.php
+++ b/src/Database/Schema/SqlAnywhereSchema.php
@@ -390,17 +390,20 @@ MYSQL;
      */
     protected function getTableConstraints($schema = '')
     {
-        if (is_array($schema)) {
-            $schema = implode("','", $schema);
+        $schemas = is_array($schema) ? array_values($schema) : [$schema];
+        $schemas = array_values(array_filter($schemas, fn ($s) => $s !== '' && $s !== null));
+        if (empty($schemas)) {
+            return [];
         }
+        $placeholders = implode(',', array_fill(0, count($schemas), '?'));
 
         $sql = <<<EOD
 SELECT icreator as constraint_schema, iname as constraint_name, creator as table_schema, tname as table_name,
 indextype as constraint_type, colnames as column_name
-FROM sys.sysindexes 
-WHERE creator IN ('{$schema}')
+FROM sys.sysindexes
+WHERE creator IN ({$placeholders})
 EOD;
-        $result = $this->connection->select($sql);
+        $result = $this->connection->select($sql, $schemas);
 
         foreach ($result as $row) {
             $row = array_change_key_case((array)$row, CASE_LOWER);
@@ -423,9 +426,9 @@ EOD;
         $sql = <<<EOD
 SELECT columns as column_nmae, foreign_creator AS 'table_schema', foreign_tname AS 'table_name', role as constraint_name,
     primary_creator AS 'referenced_table_schema', primary_tname AS 'referenced_table_name'
-FROM SYS.SYSFOREIGNKEYS WHERE foreign_creator IN ('{$schema}')
+FROM SYS.SYSFOREIGNKEYS WHERE foreign_creator IN ({$placeholders})
 EOD;
-        $result = $this->connection->select($sql);
+        $result = $this->connection->select($sql, $schemas);
         $constraints = [];
         foreach ($result as $row) {
             $row = array_change_key_case((array)$row, CASE_LOWER);

--- a/tests/Security/SchemaInterpolationTest.php
+++ b/tests/Security/SchemaInterpolationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DreamFactory\Core\SqlAnywhere\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: SqlAnywhereSchema getTableConstraints must parameterize the
+ * creator/foreign_creator IN clauses.
+ */
+class SchemaInterpolationTest extends TestCase
+{
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Database/Schema/SqlAnywhereSchema.php';
+        $this->assertFileExists($sourcePath);
+        $this->contents = file_get_contents($sourcePath);
+    }
+
+    public function testNoSchemaInterpolation(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            "/IN\s*\(\s*'\{\\\$schema\}'\s*\)/",
+            $this->contents,
+            'No \$schema must be interpolated single-quoted into IN clauses'
+        );
+    }
+
+    public function testInClauseUsesPlaceholders(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/array_fill\s*\(\s*0\s*,\s*count\s*\(\s*\$schemas\s*\)/',
+            $this->contents,
+            'Multi-schema IN list must use array_fill ?-placeholder list'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

May 2026 security audit hardening merge for this package.

## Validation

Validated as part of the DreamFactory May 2026 security merge wave:

- Composer validation passed for all scoped packages.
- Package security tests passed where present/applicable.
- Integrated `df-test sqldb` passed.
- Integrated `df-test user` passed.
- Dev-stack `df-check` passed.
- File API, OpenAPI, auth/session, system metadata, and generated API CRUD smoke tests passed.
- Generated API CRUD passed for PostgreSQL, MySQL, and SQL Server.
- Laravel 13 / PHP 8.5 bundle smoke passed with `ext-mongodb 2.3.0`.

See the local validation report: `security-merge-validation-2026-05-11.md`.
